### PR TITLE
fix update.py

### DIFF
--- a/src/update.py
+++ b/src/update.py
@@ -55,7 +55,6 @@ class ModelUpdate(object):
                     if iter > 0: 
                         for w, w_t in zip(local_net.parameters(), net.parameters()):
                             loss += self.args.mu / 2. * torch.pow(torch.norm(w.data - w_t.data), 2)
-                            w_t.grad.data += self.args.mu * (w_t.data - w.data)
                         
                 loss.backward()
                 


### PR DESCRIPTION
```
net.zero_grad()
log_probs = net(images)
loss = self.loss_func(log_probs, labels)

# FedProx: https://arxiv.org/abs/1812.06127
if self.args.fed == 'fedprox':
    if iter > 0: 
        for w, w_t in zip(local_net.parameters(), net.parameters()):
            loss += self.args.mu / 2. * torch.pow(torch.norm(w.data - w_t.data), 2)
            ### w_t.grad.data += self.args.mu * (w_t.data - w.data)
```
Net.zero_grad kept net.grad zero. That line of code makes no sense.
```
w_t.grad.data += self.args.mu * (w_t.data - w.data)
```